### PR TITLE
fix: release at commit rather than from latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.sha }}
           submodules: true
       
 
@@ -172,6 +173,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
 
       - name: Release
         uses: Greenroom-Robotics/ros_semantic_release_action@main


### PR DESCRIPTION
- if you trigger a release, and someone pushes code between the trigger and when sematic runs, it will fail due to a mismatch between local and remote repo.
- Proposal is to trigger the action at the commit point of the repo which will prevent this from occuring