### PR TITLE
fix: drop sha pin on action-repo checkout

### DIFF
--- a/.github/workflows/recipes-release.yml
+++ b/.github/workflows/recipes-release.yml
@@ -47,7 +47,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: Greenroom-Robotics/ros_semantic_release_action
-          ref: ${{ github.workflow_sha }}
           path: ${{ env.RELEASE_TOOLING_DIR }}
 
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
The reusable workflow's "Checkout release-tooling" step was pinning the action-repo checkout to \`github.workflow_sha\`. In a reusable workflow that variable resolves to the **caller's** HEAD SHA (e.g. the source repo's), not the action repo's — so the checkout fails with \`upload-pack: not our ref\`.

Verified failure mode: https://github.com/greenroom-robotics/platform_release_testing/actions/runs/25507496946

Drop the pin entirely. \`actions/checkout@v6\` defaults to the repo's default branch (main), which is what we want — release.config.js / package.json evolve as one unit alongside the workflow YAML, no need to lock-step.

## Test plan
- [ ] Re-dispatch \`Pixi Release\` on \`platform_release_testing\` after merge; checkout step should succeed