### PR TITLE
fix: stub package.json at runtime for semantic-release-monorepo

### DIFF
--- a/.github/workflows/recipes-release.yml
+++ b/.github/workflows/recipes-release.yml
@@ -60,6 +60,15 @@ jobs:
           npm --prefix "$RELEASE_TOOLING_DIR" ci
           cargo install --locked toml-cli
 
+      # semantic-release-monorepo reads package.json at the source repo
+      # root for the package name. Source repos don't carry one (they use
+      # pixi.toml). Stub it at runtime; never committed.
+      - name: Stub package.json for semantic-release-monorepo
+        run: |
+          if [ ! -f package.json ]; then
+            printf '{"name":"%s","private":true}\n' "$PACKAGE" > package.json
+          fi
+
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
\`semantic-release-monorepo\` reads a \`package.json\` at the source repo root for the package name. Source repos use pixi.toml as their manifest and don't carry a \`package.json\`, so the plugin crashes with \`ENOENT\`.

We can't put multi-package source repos out of scope (platform_toolbox has 16 packages), so dropping \`semantic-release-monorepo\` isn't an option. Instead: write a stub \`package.json\` at runtime in the workflow, before semantic-release runs. Never committed in source repos.

Failure that motivated this: https://github.com/greenroom-robotics/platform_release_testing/actions/runs/25507747119

## What changed
Adds one workflow step that creates \`package.json\` only if missing:
\`\`\`bash
printf '{"name":"%s","private":true}\n' "\$PACKAGE" > package.json
\`\`\`

## Test plan
- [ ] Re-dispatch \`Pixi Release\` on \`platform_release_testing\` after merge; semantic-release-monorepo should resolve, scope commit analysis to \`packages/release_testing_msgs/\`, and dispatch a recipes bump