### PR TITLE
fix: run semantic-release from package dir for monorepo support

### DIFF
--- a/.github/workflows/recipes-release.yml
+++ b/.github/workflows/recipes-release.yml
@@ -60,20 +60,23 @@ jobs:
           npm --prefix "$RELEASE_TOOLING_DIR" ci
           cargo install --locked toml-cli
 
-      # semantic-release-monorepo reads package.json at the source repo
-      # root for the package name. Source repos don't carry one (they use
-      # pixi.toml). Stub it at runtime; never committed.
+      # semantic-release-monorepo identifies the package by reading
+      # package.json from cwd. Source repos use pixi.toml as their manifest
+      # — stub a package.json inside the package dir at runtime. Never
+      # committed (each source repo's caller workflow owns this dir).
       - name: Stub package.json for semantic-release-monorepo
         run: |
-          if [ ! -f package.json ]; then
-            printf '{"name":"%s","private":true}\n' "$PACKAGE" > package.json
+          if [ ! -f "$PACKAGE_PATH/package.json" ]; then
+            printf '{"name":"%s","private":true}\n' "$PACKAGE" \
+              > "$PACKAGE_PATH/package.json"
           fi
 
       - name: Run semantic-release
+        working-directory: ${{ env.PACKAGE_PATH }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RECIPES_REPO: ${{ inputs.recipes_repo }}
         run: |
-          npm --prefix "$RELEASE_TOOLING_DIR" exec -- \
-            semantic-release --extends "./$RELEASE_TOOLING_DIR/release.config.js"
+          npm --prefix "$GITHUB_WORKSPACE/$RELEASE_TOOLING_DIR" exec -- \
+            semantic-release --extends "$GITHUB_WORKSPACE/$RELEASE_TOOLING_DIR/release.config.js"

--- a/release.config.js
+++ b/release.config.js
@@ -1,27 +1,37 @@
 // semantic-release config for the reusable workflow.
-// Reads runtime parameters from env vars set by the workflow.
+//
+// Runtime contract: semantic-release runs with cwd = the package directory
+// (so semantic-release-monorepo can find the stub package.json there and
+// scope commits to that path). Paths must be absolute so they don't
+// depend on cwd. GITHUB_WORKSPACE is the source repo root on the runner.
+const path = require('path');
+
 const pkg = process.env.PACKAGE;
 const pkgPath = process.env.PACKAGE_PATH;
-const tooling = process.env.RELEASE_TOOLING_DIR || '_release_tooling';
+const repoRoot = process.env.GITHUB_WORKSPACE;
+const toolingRel = process.env.RELEASE_TOOLING_DIR || '_release_tooling';
 
-if (!pkg || !pkgPath) {
-  throw new Error('PACKAGE and PACKAGE_PATH env vars are required');
+if (!pkg || !pkgPath || !repoRoot) {
+  throw new Error('PACKAGE, PACKAGE_PATH, and GITHUB_WORKSPACE env vars are required');
 }
 
+const pkgRoot = path.join(repoRoot, pkgPath);
+const tooling = path.join(repoRoot, toolingRel);
+
 module.exports = {
+  extends: 'semantic-release-monorepo',
   branches: ['main'],
   tagFormat: `${pkg}@\${version}`,
   plugins: [
-    ['semantic-release-monorepo', { mainPackage: pkgPath }],
     ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
     ['@semantic-release/release-notes-generator', { preset: 'conventionalcommits' }],
-    ['@semantic-release/changelog', { changelogFile: `${pkgPath}/CHANGELOG.md` }],
+    ['@semantic-release/changelog', { changelogFile: `${pkgRoot}/CHANGELOG.md` }],
     ['@semantic-release/exec', {
-      prepareCmd: `toml set ${pkgPath}/pixi.toml 'package.version' \${nextRelease.version} > ${pkgPath}/pixi.toml.new && mv ${pkgPath}/pixi.toml.new ${pkgPath}/pixi.toml`,
+      prepareCmd: `toml set ${pkgRoot}/pixi.toml 'package.version' \${nextRelease.version} > ${pkgRoot}/pixi.toml.new && mv ${pkgRoot}/pixi.toml.new ${pkgRoot}/pixi.toml`,
       successCmd: `${tooling}/scripts/dispatch-release.sh \${nextRelease.version} \${nextRelease.gitHead}`,
     }],
     ['@semantic-release/git', {
-      assets: [`${pkgPath}/pixi.toml`, `${pkgPath}/CHANGELOG.md`],
+      assets: [`${pkgRoot}/pixi.toml`, `${pkgRoot}/CHANGELOG.md`],
       message: `chore(release): ${pkg}@\${nextRelease.version} [skip ci]\n\n\${nextRelease.notes}`,
     }],
     '@semantic-release/github',


### PR DESCRIPTION
## Summary
\`semantic-release-monorepo\` is an \`extends\`-able config base, not a plugin. It identifies the current package by reading \`package.json\` from cwd. Two changes:

1. \`release.config.js\` uses \`extends: 'semantic-release-monorepo'\` instead of listing it as a plugin.
2. The workflow runs semantic-release with \`working-directory: \$PACKAGE_PATH\` so monorepo can detect the package, and stubs \`\$PACKAGE_PATH/package.json\` (not the source repo root) before invoking. Paths in \`release.config.js\` are absolute (\`\$GITHUB_WORKSPACE/<path>\`) so they don't break when cwd changes.

Failure: https://github.com/greenroom-robotics/platform_release_testing/actions/runs/25510220363

## Test plan
- [ ] Re-dispatch \`Pixi Release\` on platform_release_testing; semantic-release should resolve, scope to \`packages/release_testing_msgs\`, compute the next version off \`release_testing_msgs@1.1.3\`, tag, push, dispatch