### PR TITLE
perf: tomlkit + 1cpu runner; disable PR labels in github plugin

### DIFF
--- a/.github/workflows/recipes-release.yml
+++ b/.github/workflows/recipes-release.yml
@@ -60,6 +60,15 @@ jobs:
           npm --prefix "$RELEASE_TOOLING_DIR" ci
           cargo install --locked toml-cli
 
+      - name: Configure git as App bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID=$(gh api "/users/${SLUG}[bot]" --jq .id)
+          git config --global user.name "${SLUG}[bot]"
+          git config --global user.email "${USER_ID}+${SLUG}[bot]@users.noreply.github.com"
+
       # semantic-release-monorepo identifies the package by reading
       # package.json from cwd. Source repos use pixi.toml as their manifest
       # — stub a package.json inside the package dir at runtime. Never

--- a/.github/workflows/recipes-release.yml
+++ b/.github/workflows/recipes-release.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=1cpu-linux-x64
     permissions:
       contents: read
     env:
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm --prefix "$RELEASE_TOOLING_DIR" ci
-          cargo install --locked toml-cli
+          pip install --quiet tomlkit
 
       - name: Configure git as App bot
         env:

--- a/release.config.js
+++ b/release.config.js
@@ -34,6 +34,11 @@ module.exports = {
       assets: [`${pkgRoot}/pixi.toml`, `${pkgRoot}/CHANGELOG.md`],
       message: `chore(release): ${pkg}@\${nextRelease.version} [skip ci]\n\n\${nextRelease.notes}`,
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failComment: false,
+      releasedLabels: false,
+      addReleases: false,
+    }],
   ],
 };

--- a/release.config.js
+++ b/release.config.js
@@ -27,7 +27,7 @@ module.exports = {
     ['@semantic-release/release-notes-generator', { preset: 'conventionalcommits' }],
     ['@semantic-release/changelog', { changelogFile: `${pkgRoot}/CHANGELOG.md` }],
     ['@semantic-release/exec', {
-      prepareCmd: `toml set ${pkgRoot}/pixi.toml 'package.version' \${nextRelease.version} > ${pkgRoot}/pixi.toml.new && mv ${pkgRoot}/pixi.toml.new ${pkgRoot}/pixi.toml`,
+      prepareCmd: `python -c "import tomlkit; p='${pkgRoot}/pixi.toml'; d=tomlkit.parse(open(p).read()); d['package']['version']='\${nextRelease.version}'; open(p,'w').write(tomlkit.dumps(d))"`,
       successCmd: `${tooling}/scripts/dispatch-release.sh \${nextRelease.version} \${nextRelease.gitHead}`,
     }],
     ['@semantic-release/git', {


### PR DESCRIPTION
Three small fixes after the smoke test:

- swap `cargo install toml-cli` (~60s) for `pip install tomlkit` (~2s); prepareCmd uses inline python
- runs-on switched to `runs-on=${{ github.run_id }}/runner=1cpu-linux-x64`
- disable `successComment`/`failComment`/`releasedLabels`/`addReleases` in `@semantic-release/github` — App token lacks `pull_requests:write`, and these post-release PR touches were the only step failing the run after a successful tag+release+dispatch