### PR TITLE
fix: use relative paths so monorepo wrapper doesn't filter assets

### DIFF
--- a/.github/workflows/recipes-release.yml
+++ b/.github/workflows/recipes-release.yml
@@ -60,6 +60,15 @@ jobs:
           npm --prefix "$RELEASE_TOOLING_DIR" ci
           cargo install --locked toml-cli
 
+      - name: Configure git as App bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID=$(gh api "/users/${SLUG}[bot]" --jq .id)
+          git config --global user.name "${SLUG}[bot]"
+          git config --global user.email "${USER_ID}+${SLUG}[bot]@users.noreply.github.com"
+
       # semantic-release-monorepo identifies the package by reading
       # package.json from cwd. Source repos use pixi.toml as their manifest
       # — stub a package.json inside the package dir at runtime. Never

--- a/.github/workflows/recipes-release.yml
+++ b/.github/workflows/recipes-release.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=1cpu-linux-x64
     permissions:
       contents: read
     env:
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm --prefix "$RELEASE_TOOLING_DIR" ci
-          cargo install --locked toml-cli
+          pip install --quiet tomlkit
 
       - name: Configure git as App bot
         env:

--- a/release.config.js
+++ b/release.config.js
@@ -1,9 +1,10 @@
 // semantic-release config for the reusable workflow.
 //
-// Runtime contract: semantic-release runs with cwd = the package directory
-// (so semantic-release-monorepo can find the stub package.json there and
-// scope commits to that path). Paths must be absolute so they don't
-// depend on cwd. GITHUB_WORKSPACE is the source repo root on the runner.
+// Runtime contract: semantic-release runs with cwd = the package directory.
+// File paths in plugin configs are relative to cwd so semantic-release-monorepo's
+// asset filter (which scopes paths to the package dir) leaves them intact.
+// The dispatch-release helper lives in the action checkout, so reference it
+// via an absolute path built from GITHUB_WORKSPACE.
 const path = require('path');
 
 const pkg = process.env.PACKAGE;
@@ -15,7 +16,6 @@ if (!pkg || !pkgPath || !repoRoot) {
   throw new Error('PACKAGE, PACKAGE_PATH, and GITHUB_WORKSPACE env vars are required');
 }
 
-const pkgRoot = path.join(repoRoot, pkgPath);
 const tooling = path.join(repoRoot, toolingRel);
 
 module.exports = {
@@ -25,13 +25,13 @@ module.exports = {
   plugins: [
     ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
     ['@semantic-release/release-notes-generator', { preset: 'conventionalcommits' }],
-    ['@semantic-release/changelog', { changelogFile: `${pkgRoot}/CHANGELOG.md` }],
+    ['@semantic-release/changelog', { changelogFile: 'CHANGELOG.md' }],
     ['@semantic-release/exec', {
-      prepareCmd: `python -c "import tomlkit; p='${pkgRoot}/pixi.toml'; d=tomlkit.parse(open(p).read()); d['package']['version']='\${nextRelease.version}'; open(p,'w').write(tomlkit.dumps(d))"`,
+      prepareCmd: `python -c "import tomlkit; d=tomlkit.parse(open('pixi.toml').read()); d['package']['version']='\${nextRelease.version}'; open('pixi.toml','w').write(tomlkit.dumps(d))"`,
       successCmd: `${tooling}/scripts/dispatch-release.sh \${nextRelease.version} \${nextRelease.gitHead}`,
     }],
     ['@semantic-release/git', {
-      assets: [`${pkgRoot}/pixi.toml`, `${pkgRoot}/CHANGELOG.md`],
+      assets: ['pixi.toml', 'CHANGELOG.md'],
       message: `chore(release): ${pkg}@\${nextRelease.version} [skip ci]\n\n\${nextRelease.notes}`,
     }],
     ['@semantic-release/github', {

--- a/release.config.js
+++ b/release.config.js
@@ -34,6 +34,11 @@ module.exports = {
       assets: [`${pkgRoot}/pixi.toml`, `${pkgRoot}/CHANGELOG.md`],
       message: `chore(release): ${pkg}@\${nextRelease.version} [skip ci]\n\n\${nextRelease.notes}`,
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failComment: false,
+      releasedLabels: false,
+      addReleases: false,
+    }],
   ],
 };

--- a/release.config.js
+++ b/release.config.js
@@ -27,7 +27,7 @@ module.exports = {
     ['@semantic-release/release-notes-generator', { preset: 'conventionalcommits' }],
     ['@semantic-release/changelog', { changelogFile: `${pkgRoot}/CHANGELOG.md` }],
     ['@semantic-release/exec', {
-      prepareCmd: `toml set ${pkgRoot}/pixi.toml 'package.version' \${nextRelease.version} > ${pkgRoot}/pixi.toml.new && mv ${pkgRoot}/pixi.toml.new ${pkgRoot}/pixi.toml`,
+      prepareCmd: `python -c "import tomlkit; p='${pkgRoot}/pixi.toml'; d=tomlkit.parse(open(p).read()); d['package']['version']='\${nextRelease.version}'; open(p,'w').write(tomlkit.dumps(d))"`,
       successCmd: `${tooling}/scripts/dispatch-release.sh \${nextRelease.version} \${nextRelease.gitHead}`,
     }],
     ['@semantic-release/git', {


### PR DESCRIPTION
Diagnosed why pixi.toml bumps weren't landing on main: `semantic-release-monorepo` wraps `@semantic-release/git` and filters `assets` to paths inside the package dir. Our absolute paths (`/home/runner/...`) didn't match, so the asset list went empty and prepare silently no-op'd — tag got created but the bump commit was never made.

Fix: switch `changelogFile`, `prepareCmd` (toml edit), and `assets` to relative paths. cwd is already the package dir, so this is correct and the wrapper leaves them alone.