### PR TITLE
fix: dedupe app-bot step; relative paths for monorepo asset filter

### DIFF
--- a/.github/workflows/recipes-release.yml
+++ b/.github/workflows/recipes-release.yml
@@ -69,15 +69,6 @@ jobs:
           git config --global user.name "${SLUG}[bot]"
           git config --global user.email "${USER_ID}+${SLUG}[bot]@users.noreply.github.com"
 
-      - name: Configure git as App bot
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          SLUG: ${{ steps.app-token.outputs.app-slug }}
-        run: |
-          USER_ID=$(gh api "/users/${SLUG}[bot]" --jq .id)
-          git config --global user.name "${SLUG}[bot]"
-          git config --global user.email "${USER_ID}+${SLUG}[bot]@users.noreply.github.com"
-
       # semantic-release-monorepo identifies the package by reading
       # package.json from cwd. Source repos use pixi.toml as their manifest
       # — stub a package.json inside the package dir at runtime. Never

--- a/release.config.js
+++ b/release.config.js
@@ -1,9 +1,10 @@
 // semantic-release config for the reusable workflow.
 //
-// Runtime contract: semantic-release runs with cwd = the package directory
-// (so semantic-release-monorepo can find the stub package.json there and
-// scope commits to that path). Paths must be absolute so they don't
-// depend on cwd. GITHUB_WORKSPACE is the source repo root on the runner.
+// Runtime contract: semantic-release runs with cwd = the package directory.
+// File paths in plugin configs are relative to cwd so semantic-release-monorepo's
+// asset filter (which scopes paths to the package dir) leaves them intact.
+// The dispatch-release helper lives in the action checkout, so reference it
+// via an absolute path built from GITHUB_WORKSPACE.
 const path = require('path');
 
 const pkg = process.env.PACKAGE;
@@ -15,7 +16,6 @@ if (!pkg || !pkgPath || !repoRoot) {
   throw new Error('PACKAGE, PACKAGE_PATH, and GITHUB_WORKSPACE env vars are required');
 }
 
-const pkgRoot = path.join(repoRoot, pkgPath);
 const tooling = path.join(repoRoot, toolingRel);
 
 module.exports = {
@@ -25,13 +25,13 @@ module.exports = {
   plugins: [
     ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
     ['@semantic-release/release-notes-generator', { preset: 'conventionalcommits' }],
-    ['@semantic-release/changelog', { changelogFile: `${pkgRoot}/CHANGELOG.md` }],
+    ['@semantic-release/changelog', { changelogFile: 'CHANGELOG.md' }],
     ['@semantic-release/exec', {
-      prepareCmd: `python -c "import tomlkit; p='${pkgRoot}/pixi.toml'; d=tomlkit.parse(open(p).read()); d['package']['version']='\${nextRelease.version}'; open(p,'w').write(tomlkit.dumps(d))"`,
+      prepareCmd: `python -c "import tomlkit; d=tomlkit.parse(open('pixi.toml').read()); d['package']['version']='\${nextRelease.version}'; open('pixi.toml','w').write(tomlkit.dumps(d))"`,
       successCmd: `${tooling}/scripts/dispatch-release.sh \${nextRelease.version} \${nextRelease.gitHead}`,
     }],
     ['@semantic-release/git', {
-      assets: [`${pkgRoot}/pixi.toml`, `${pkgRoot}/CHANGELOG.md`],
+      assets: ['pixi.toml', 'CHANGELOG.md'],
       message: `chore(release): ${pkg}@\${nextRelease.version} [skip ci]\n\n\${nextRelease.notes}`,
     }],
     ['@semantic-release/github', {


### PR DESCRIPTION
Two cleanups in one:

1. **Dedupe `Configure git as App bot`** — PRs #10 and #11 both added the step independently (PR #11 was branched before #10 merged). Both copies landed on main; consolidating to one.

2. **Relative paths in plugin configs** — supersedes/replaces PR #12 (closing). `semantic-release-monorepo` filters `@semantic-release/git` assets to paths inside the package dir; absolute paths failed the filter, so the bump commit silently never happened. Switching `changelogFile`, the toml-edit prepareCmd, and `assets` to relative paths (cwd is already the package dir) lets the wrapper leave them alone.