### PR TITLE
feat: add lfs_include input to fetch LFS files on build checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,10 @@ on:
         description: 'Packages to ignore (comma-separated). Use "pkg" for all distros or "distro:pkg" for specific distro'
         type: string
         default: ''
+      lfs_include:
+        description: 'Glob of LFS files to fetch on the build checkout (gitignore-style, comma-separated). Empty = no LFS fetch.'
+        type: string
+        default: ''
     secrets:
       token:
         required: true
@@ -119,7 +123,13 @@ jobs:
         with:
           ref: ${{ github.sha }}
           submodules: true
-      
+
+      - name: Fetch LFS files
+        if: inputs.lfs_include != ''
+        shell: bash
+        run: |
+          git lfs install --local
+          git lfs pull --include="${{ inputs.lfs_include }}"
 
       - name: Create COLCON_IGNORE for excluded packages
         if: inputs.ignore_packages != ''


### PR DESCRIPTION
## Summary
- Adds a new `lfs_include` workflow input (default empty) to the reusable release workflow.
- When set, the build job runs `git lfs install --local && git lfs pull --include="<glob>"` after the checkout so LFS-tracked sources land on disk before the build container is started.
- Release job is intentionally left without LFS — it only consumes prebuilt `.deb` artifacts from the build matrix.

Motivation: `platform_control/packages/mako_bin` ships LFS-tracked binaries (`packages/mako_bin/bin/**`) that need to be present at build time. Without this, the checkout leaves pointer files in place and the resulting Debian is broken. A sparse include keeps unrelated LFS payloads (mcap recordings, PNGs) out of release builds.

## Test plan
- [ ] Trigger the platform_control release workflow with the companion PR that sets `lfs_include: 'packages/mako_bin/bin/**'` and confirm the `mako_bin` `.deb` contains real binaries (not LFS pointers).
- [ ] Trigger a release for an unrelated package that does not set `lfs_include` and confirm the LFS step is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)