### PR TITLE
feat: vendored recipe dispatch support

### DIFF
--- a/dispatch-payload.schema.json
+++ b/dispatch-payload.schema.json
@@ -8,8 +8,8 @@
   "properties": {
     "package": {
       "type": "string",
-      "description": "Bare ROS package name (no ros-<distro>- prefix).",
-      "pattern": "^[a-z][a-z0-9_]*$"
+      "description": "Package name as it appears in the recipes repo: bare ROS name, or conda name (hyphens allowed) for vendored recipes.",
+      "pattern": "^[a-z][a-z0-9_-]*$"
     },
     "version": {
       "type": "string",
@@ -25,6 +25,15 @@
       "type": "string",
       "description": "SHA of the tagged commit.",
       "pattern": "^[0-9a-f]{40}$"
+    },
+    "manifest_type": {
+      "type": "string",
+      "description": "Manifest format the source repo uses. Defaults to pixi.toml when omitted.",
+      "enum": ["pixi.toml", "package.xml"]
+    },
+    "subdir": {
+      "type": "string",
+      "description": "Path from source-repo root to the package's manifest dir. Omitted when the package sits at the repo root."
     }
   }
 }

--- a/scripts/dispatch-latest-tag.sh
+++ b/scripts/dispatch-latest-tag.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Resolves the latest release tag for ${PACKAGE} (format <pkg>@X.Y.Z, ignoring
+# per-arch tags like <pkg>@X.Y.Z-amd64) and fires the package-released
+# repository_dispatch for it via dispatch-release.sh.
+#
+# For release workflows that tag via the composite action instead of the
+# recipes-release reusable workflow (which dispatches from semantic-release's
+# successCmd). Idempotent: re-dispatching an already-bumped version no-ops in
+# the recipes repo (bump route leaves the recipe unchanged, open-pr stages
+# nothing and exits).
+#
+# Required env: PACKAGE, PACKAGE_PATH, MANIFEST_TYPE, GITHUB_REPOSITORY,
+#               RECIPES_REPO, GH_TOKEN.
+set -euo pipefail
+
+git fetch --tags --quiet
+
+# `|| true`: under pipefail a no-match grep would kill the script here,
+# skipping the explicit error below.
+tag=$(git tag --list "${PACKAGE}@*" --sort=-v:refname \
+  | grep -E "^${PACKAGE}@[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1 || true)
+
+if [ -z "${tag}" ]; then
+  echo "::error::no release tag found matching ${PACKAGE}@X.Y.Z" >&2
+  exit 1
+fi
+
+version="${tag#"${PACKAGE}"@}"
+sha=$(git rev-list -n 1 "${tag}")
+
+echo "::notice::dispatching ${PACKAGE}@${version} (${sha})"
+exec "$(dirname "$0")/dispatch-release.sh" "${version}" "${sha}"


### PR DESCRIPTION
Relaxes the dispatch payload `package` pattern to allow conda names (`is-core`, `is-ros2`) for vendored recipes, and adds `scripts/dispatch-latest-tag.sh` for release workflows that tag via the composite action (rather than the `recipes-release` reusable workflow that dispatches from semantic-release's `successCmd`).

- `package` pattern: `^[a-z][a-z0-9_]*$` → `^[a-z][a-z0-9_-]*$`; `manifest_type`/`subdir` properties retained so this copy stays identical to the ros-recipes one
- `dispatch-latest-tag.sh` resolves the latest exact `<pkg>@X.Y.Z` tag (ignoring per-arch `-amd64`/`-arm64` tags) and delegates to the existing `dispatch-release.sh`; `|| true` guards the no-match grep under `pipefail` so the explicit error message is reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)