### PR TITLE
feat: add skip_tag input to reusable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,10 @@ on:
         description: 'Generate changelog'
         type: boolean
         default: false
+      skip_tag:
+        description: 'Skip creating the git tag and GitHub release (use when another workflow owns tagging, e.g. the pixi release)'
+        type: boolean
+        default: false
       gpu:
         description: 'Enable GPU support'
         type: boolean
@@ -192,9 +196,9 @@ jobs:
           token: ${{ secrets.token }}
           package_dir: ${{ inputs.package_dir }}
           package: ${{ inputs.package }}
-          github_release: true
+          github_release: ${{ !inputs.skip_tag }}
           public: ${{ inputs.public }}
           changelog: ${{ inputs.changelog }}
           skip_build: true
-          skip_tag: false
+          skip_tag: ${{ inputs.skip_tag }}
           release_branches: ${{ inputs.release_branches }}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This handles the full pipeline: setup, matrix builds across architectures/distro
 | `build_arm64`      | boolean | `true`                    | Build for arm64                            |
 | `public`           | boolean | `false`                   | Publish to public PPA                      |
 | `changelog`        | boolean | `false`                   | Generate changelog                         |
+| `skip_tag`         | boolean | `false`                   | Skip git tag + GitHub release (another workflow owns tagging) |
 | `gpu`              | boolean | `false`                   | Enable GPU support                         |
 | `runner_amd64`     | string  | `'4vcpu-ubuntu-2404'`     | Runner for amd64 builds                    |
 | `runner_arm64`     | string  | `'4vcpu-ubuntu-2404-arm'` | Runner for arm64 builds                    |


### PR DESCRIPTION
Adds a `skip_tag` input (boolean, default `false`) to the reusable `release.yml` workflow. When set, the release job skips both the git tag and the GitHub release.

This lets repos that have migrated tagging to the pixi (mise) release run the standard deb release without colliding on `pkg@ver` tags. Default `false` keeps all existing consumers unchanged.

- Release job: `skip_tag: ${{ inputs.skip_tag }}`, `github_release: ${{ !inputs.skip_tag }}`
- Documented in README workflow inputs table