### PR TITLE
feat: attribute release commit to app bot and push as app; forward cli_branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
           done
 
       - name: Build
-        uses: Greenroom-Robotics/ros_semantic_release_action@tenzinplatter/release-as-app
+        uses: Greenroom-Robotics/ros_semantic_release_action@main
         with:
           token: ${{ secrets.token }}
           package_dir: ${{ inputs.package_dir }}
@@ -223,7 +223,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token || secrets.token }}
 
       - name: Release
-        uses: Greenroom-Robotics/ros_semantic_release_action@tenzinplatter/release-as-app
+        uses: Greenroom-Robotics/ros_semantic_release_action@main
         with:
           token: ${{ steps.app-token.outputs.token || secrets.token }}
           # bot_slug defaults to the greenroom App bot in the action, so the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
           done
 
       - name: Build
-        uses: Greenroom-Robotics/ros_semantic_release_action@main
+        uses: Greenroom-Robotics/ros_semantic_release_action@tenzinplatter/release-as-app
         with:
           token: ${{ secrets.token }}
           package_dir: ${{ inputs.package_dir }}
@@ -223,7 +223,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token || secrets.token }}
 
       - name: Release
-        uses: Greenroom-Robotics/ros_semantic_release_action@main
+        uses: Greenroom-Robotics/ros_semantic_release_action@tenzinplatter/release-as-app
         with:
           token: ${{ steps.app-token.outputs.token || secrets.token }}
           # bot_slug defaults to the greenroom App bot in the action, so the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,21 @@ on:
         description: 'Glob of LFS files to fetch on the build checkout (gitignore-style, comma-separated). Empty = no LFS fetch.'
         type: string
         default: ''
+      cli_branch:
+        description: 'Branch of platform_cli to install (for testing unreleased release-tooling changes).'
+        type: string
+        default: 'main'
     secrets:
       token:
         required: true
+      # Optional: provide the gremlin GitHub App's credentials to push the
+      # release commit/tag and create the release AS the App (its identity and
+      # permissions) instead of with the PAT + semantic-release-bot. When
+      # omitted, falls back to `token` and the default identity.
+      gh_app_client_id:
+        required: false
+      gh_app_private_key:
+        required: false
 
 jobs:
   setup:
@@ -180,21 +192,44 @@ jobs:
           skip_tag: true
           gpu: ${{ inputs.gpu }}
           release_branches: ${{ inputs.release_branches }}
+          cli_branch: ${{ inputs.cli_branch }}
 
   release:
     name: Create Release
     runs-on: ${{ inputs.runner_release }}
     needs: build
+    # `secrets` isn't allowed in `if`, so surface "were App creds provided?" as
+    # an env flag the steps below can branch on.
+    env:
+      HAS_APP_CREDS: ${{ secrets.gh_app_client_id != '' && secrets.gh_app_private_key != '' }}
 
     steps:
+      # Mint an installation token so the release commit/tag is pushed and the
+      # GitHub release created AS the App (its permissions), not the PAT.
+      - name: Mint App token
+        id: app-token
+        if: ${{ env.HAS_APP_CREDS == 'true' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.gh_app_client_id }}
+          private-key: ${{ secrets.gh_app_private_key }}
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
+          # checkout stores this token in the git remote; @semantic-release/git
+          # pushes the release commit + tag with it. App token when available,
+          # else the PAT (previous behaviour).
+          token: ${{ steps.app-token.outputs.token || secrets.token }}
 
       - name: Release
         uses: Greenroom-Robotics/ros_semantic_release_action@main
         with:
-          token: ${{ secrets.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.token }}
+          # bot_slug defaults to the greenroom App bot in the action, so the
+          # release commit is attributed to it by default. App creds (above)
+          # additionally give the push the App's permissions; without them the
+          # commit is still labelled the bot but pushed with the PAT.
           package_dir: ${{ inputs.package_dir }}
           package: ${{ inputs.package }}
           github_release: ${{ !inputs.skip_tag }}
@@ -203,3 +238,4 @@ jobs:
           skip_build: true
           skip_tag: ${{ inputs.skip_tag }}
           release_branches: ${{ inputs.release_branches }}
+          cli_branch: ${{ inputs.cli_branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,8 @@ on:
     secrets:
       token:
         required: true
-      # Optional: provide the gremlin GitHub App's credentials to push the
-      # release commit/tag and create the release AS the App (its identity and
+      # Optional: provide a GitHub App's credentials to push the release
+      # commit/tag and create the release AS the App (its identity and
       # permissions) instead of with the PAT + semantic-release-bot. When
       # omitted, falls back to `token` and the default identity.
       gh_app_client_id:

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,9 @@ inputs:
   secrets:
     description: "JSON string of secrets to pass to docker build (e.g. '{\"API_TOKEN_GITHUB\": \"./.secrets/github_token\", \"apt_conf\": \"./.secrets/apt.conf\"}')"
     default: "{}"
+  bot_slug:
+    description: "GitHub App slug to attribute the release commit to. Defaults to the greenroom App bot; set empty to fall back to semantic-release's default identity."
+    default: "greenroom-gremlin"
 
 runs:
   using: "composite"
@@ -97,6 +100,26 @@ runs:
         pattern: build-*
         path: ${{ inputs.package_dir }}
         merge-multiple: true
+
+    # Attribute the release commit to the App bot instead of semantic-release-bot.
+    # Only the release job (skip_build) commits; build legs never push. The
+    # numeric user id in the noreply email links the commit to the App account
+    # so GitHub renders its avatar. semantic-release reads these GIT_* env vars.
+    - name: Configure git identity as App bot
+      if: ${{ inputs.skip_build == 'true' && inputs.bot_slug != '' }}
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        SLUG: ${{ inputs.bot_slug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        user_id="$(gh api "/users/${SLUG}[bot]" --jq .id)"
+        {
+          echo "GIT_AUTHOR_NAME=${SLUG}[bot]"
+          echo "GIT_AUTHOR_EMAIL=${user_id}+${SLUG}[bot]@users.noreply.github.com"
+          echo "GIT_COMMITTER_NAME=${SLUG}[bot]"
+          echo "GIT_COMMITTER_EMAIL=${user_id}+${SLUG}[bot]@users.noreply.github.com"
+        } >> "$GITHUB_ENV"
 
     - name: Create Release
       env:


### PR DESCRIPTION
Deb-path release-tooling changes:

- `bot_slug` input (default `greenroom-gremlin`) sets the git author/committer to the App bot for the release commit.
- Optional `gh_app_client_id`/`gh_app_private_key` secrets mint an App token so the release commit/tag is pushed and the GitHub release created with the App's permissions. Falls back to the PAT when omitted.
- Forward `cli_branch` to both the build and release action calls (test unreleased `platform_cli` release tooling).

Validated end-to-end in `platform_release_testing`: commit authored by `greenroom-gremlin[bot]`, package-named subject, tag + recipes PR created.