### PR TITLE
chore: bump mise actions to v8

### DIFF
--- a/.github/workflows/deb-pixi-release.yml
+++ b/.github/workflows/deb-pixi-release.yml
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: greenroom-robotics/mise/.github/actions/setup@v6
+      - uses: greenroom-robotics/mise/.github/actions/setup@v8
         id: setup
         with:
           gh-app-client-id: ${{ secrets.gh-app-client-id }}
@@ -137,9 +137,6 @@ jobs:
           fi
           pixi run --manifest-path "$MISE_MANIFEST" mise ci build "${args[@]}"
 
-      - if: always()
-        uses: greenroom-robotics/conda-channel-proxy/.github/actions/teardown@v5
-
   # Mirrors platform_toolbox's pixi job: opens/updates the conda recipe PR
   # against the tag `deb` just created, once both the deb release and the
   # pixi build have been verified.
@@ -155,7 +152,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: greenroom-robotics/mise/.github/actions/recipes-pr@v6
+      - uses: greenroom-robotics/mise/.github/actions/recipes-pr@v8
         with:
           dispatch-sha: ${{ github.sha }}
           package: ${{ inputs.package }}


### PR DESCRIPTION
Points `setup` and `recipes-pr` at mise `@v8`, and drops the conda-channel-proxy teardown step: v8 installs the Greenroom pixi fork, which reads the `az://` channels via the ambient `azure/login`, so there is no proxy to tear down.

Input sets were checked against v8's `action.yml` — the Azure inputs this workflow already passes are exactly what v8 requires.

[sc-23514] [sc-21396]